### PR TITLE
Use re to parse the response url in _get_authorization

### DIFF
--- a/src/graph_onedrive/_main.py
+++ b/src/graph_onedrive/_main.py
@@ -1,6 +1,7 @@
 """Microsoft OneDrive functions using the Graph API.
 """
 import json
+import re
 import urllib
 import os
 import secrets
@@ -149,11 +150,11 @@ class OneDrive:
         response = input("Step 4: paste the response here: ")
 
         # Verify the state which ensures the response is for this request
-        return_state = response[
-            (response.find("state") + len("state") + 1) : (
-                response.find("&session_state")
-            )
-        ]
+        match = re.search("&state=([^&]+)", response)
+        if match and match.lastindex > 0:
+            return_state = match.group(1)
+        else:
+            return_state = None
         if state != return_state:
             raise Exception(
                 "The response does not correspond to this original request."


### PR DESCRIPTION
The string "&session_state" was expected to be always present at the end of the response url to extract the "state" field correctly, but sometimes the url does not end like that.