### PR TITLE
remove confusion for file_path argument in uploading a file.

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -580,7 +580,7 @@ item_id = my_instance.upload_file(
 
 Positional arguments:
 
-* file_path (str|Path) -- path of the file on the drive
+* file_path (str|Path) -- path of the file which you want to upload from your local drive.
 
 Keyword arguments:
 


### PR DESCRIPTION
file_path argument is nothing but full path of your local file which you wanna upload on onedrive.