### PR TITLE
Improve upload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Added py.typed for mypy typing support
+* Improved upload to attempt to retain file creation and modified metadata (Issue [#13](https://github.com/dariobauer/graph-onedrive/issues/13))
 
 
 ## Released
@@ -13,7 +14,7 @@ Released 2021-10-29
 
 * Improved file download to asynchronously download using multiple connections
 * Added HTTPX and aiofiles packages as dependencies
-* Replaced Requests package with HTTPX (Issue #11)
+* Replaced Requests package with HTTPX (Issue [#11](https://github.com/dariobauer/graph-onedrive/issues/11))
 * Added verbose keyword arguments to download and upload functions
 * Improved error handling
 * item_type, is_file, is_folder methods added
@@ -27,9 +28,9 @@ Released 2021-10-29
 Released 2021-10-21
 
 * Major improvements to the cli, now uses argparse, docs updated
-* Removed access token validation (Issue #4)
-* Allowed access token response to continue when no refresh token provided (Issue #6)
-* Various dictionary value lookups improved to account for missing keys (Issue #7)
+* Removed access token validation (Issue [#4](https://github.com/dariobauer/graph-onedrive/issues/4))
+* Allowed access token response to continue when no refresh token provided (Issue [#6](https://github.com/dariobauer/graph-onedrive/issues/6))
+* Various dictionary value lookups improved to account for missing keys (Issue [#7](https://github.com/dariobauer/graph-onedrive/issues/7))
 
 ### Version 0.0.1a9
 
@@ -37,7 +38,7 @@ Released 2021-10-20
 
 * Improved code typing
 * Updated code formatting
-* Improved validation of authorization codes and access tokens (Issues #3 & #4)
+* Improved validation of authorization codes and access tokens (Issues [#3](https://github.com/dariobauer/graph-onedrive/issues/3) & [#4](https://github.com/dariobauer/graph-onedrive/issues/4))
 
 ### Version 0.0.1a8
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -580,7 +580,7 @@ item_id = my_instance.upload_file(
 
 Positional arguments:
 
-* file_path (str|Path) -- path of the origin file to upload (this is the path to the file on your computer which you are wanting to upload)
+* file_path (str|Path) -- path of the local source file to upload (path to the file on your computer which you are wanting to upload)
 
 Keyword arguments:
 

--- a/src/graph_onedrive/_cli.py
+++ b/src/graph_onedrive/_cli.py
@@ -392,10 +392,10 @@ def instance(
                 elif not onedrive.is_folder(str(parent_folder_id)):
                     print("The item id is not a folder.")
                     continue
-                response = onedrive.upload_file(
+                item_id = onedrive.upload_file(
                     file_path, new_file_name, parent_folder_id, verbose=True
                 )
-                print(response)
+                print(f"New file item id: {item_id}")
 
             elif command in ["od", "onedrive", "drive"]:
                 print("Drive id:    ", onedrive._drive_id)

--- a/src/graph_onedrive/_onedrive.py
+++ b/src/graph_onedrive/_onedrive.py
@@ -934,14 +934,15 @@ class OneDrive:
                 },
             }
         }
-
+        breakpoint()
         # Make the Graph API request for the upload session
         if verbose:
             print(f"Requesting upload session")
-        response = httpx.post(request_url, headers=self._headers)
+        response = httpx.post(request_url, headers=self._headers, json=body)
 
         # Validate upload session request response and parse
         if response.status_code != 200:
+            print(response.text)
             try:
                 error = response.json()["error"]
                 error_message = error.get("message")

--- a/src/graph_onedrive/_onedrive.py
+++ b/src/graph_onedrive/_onedrive.py
@@ -10,6 +10,7 @@ import urllib.parse
 import warnings
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from pathlib import Path
 from time import sleep
 from typing import Any
@@ -884,10 +885,16 @@ class OneDrive:
                 # Likely Linux OS, fall back to last modified.
                 file_created = stat.st_mtime
         file_created_str = (
-            datetime.fromtimestamp(file_created).isoformat(timespec="seconds") + "Z"
+            datetime.fromtimestamp(file_created)
+            .astimezone(timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
         )
         file_modified_str = (
-            datetime.fromtimestamp(file_modified).isoformat(timespec="seconds") + "Z"
+            datetime.fromtimestamp(file_modified)
+            .astimezone(timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
         )
 
         # Create request url for the upload session


### PR DESCRIPTION
Improvements to the upload_file method to attempt to retain the local file creation and last modified metadata.

Note features are platform specific:

- Last modified datetime should work on all platforms.
- Creation datetime differs depending on platform, should work on modern versions Windows and Mac OS, but does not work on Linux-based platforms where file creation time is not practically accessible. Method falls back on last modified datetime.

Closes Issue #13 in relation to uploads. Download metadata is not retained at this time.