### PR TITLE
Improvements to listing directories and detailing items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 * Imporved developer experience by adding tests, testing automation (tox, GitHub Actions), requirements files, pre-commit improvements
 * Input type checks added and error messaging improved
 * Fixed bug in sharing links part of the CLI
+* Listing a directory now gets all items, even if there are over 200
+* New method detail_item_path details an item by providing a drive path instead of id
 
 
 ## Released

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -366,7 +366,7 @@ Returns:
 
 #### detail_item
 
-Retrieves the metadata for an item.
+Retrieves the metadata for an item by id.
 
 ```python
 item_details = my_instance.detail_item(item_id, verbose=False)
@@ -375,6 +375,26 @@ item_details = my_instance.detail_item(item_id, verbose=False)
 Positional arguments:
 
 * item_id (str) -- item id of the folder or file
+
+Keyword arguments:
+
+* verbose (bool) -- print the main parts of the item metadata (default = False)
+
+Returns:
+
+* items (dict) -- metadata of the requested item
+
+#### detail_item_path
+
+Retrieves the metadata for an item by path.
+
+```python
+item_details = my_instance.detail_item_path(item_path, verbose=False)
+```
+
+Positional arguments:
+
+* item_path (str) -- drive root path to the folder or file (e.g. "/pictures/Holiday 01.jpg")
 
 Keyword arguments:
 

--- a/src/graph_onedrive/_cli.py
+++ b/src/graph_onedrive/_cli.py
@@ -309,8 +309,11 @@ def instance(
                 onedrive.list_directory(folder_id, verbose=True)
 
             elif command in ["de", "detail"]:
-                item_id = input("Item id to detail: ").strip()
-                onedrive.detail_item(item_id, verbose=True)
+                item_id = input("Item id or root path starting with /: ").strip()
+                if item_id[0] == "/":
+                    onedrive.detail_item_path(item_id, verbose=True)
+                else:
+                    onedrive.detail_item(item_id, verbose=True)
 
             elif command in ["sl", "link"]:
                 item_id = input("Item id to create a link for: ").strip()

--- a/tests/_onedrive_test.py
+++ b/tests/_onedrive_test.py
@@ -412,6 +412,12 @@ class TestItemDetails:
     def test_detail_item_failure(self):
         ...
 
+    # detail_item_path
+    def test_detail_item_path(self, onedrive):
+        item_path = "Contoso Electronics/Contoso Electronics Sales Presentation.pptx"
+        item_details = onedrive.detail_item_path(item_path)
+        assert item_details.get("name") == "Contoso Electronics Sales Presentation.pptx"
+
     # item_type
     @pytest.mark.parametrize(
         "item_id, exp_type",


### PR DESCRIPTION
Minor improvements:
- [NEW] `detail_item_path` method added allowing an item to be detailed from it's drive path rather than item id
- [NEW] cli, docs, tests updated to support new method
- [FIXED] `list_directory` not makes subsequent requests to get all items if the number of items in a directory exceed 200