### PR TITLE
Config file TOML support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,4 +52,4 @@ repos:
     rev: v0.930
     hooks:
       - id: mypy
-        additional_dependencies: [types-aiofiles, types-PyYAML]
+        additional_dependencies: [types-aiofiles, types-PyYAML, types-toml]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Added search method to OneDrive class and CLI
 * Added optional yaml config files support with optional PyYAML dependency
+* Added optional toml config files support with optional TOML dependency
+* Improved logging
 
 ## Released
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -50,7 +50,7 @@ The configuration details required are below displayed in the typical configurat
 }
 ```
 
- An equivalent YAML format can also be used when the corresponding optional dependency is installed.
+Equivalent YAML and TOML formats can also be used when the corresponding optional dependency is installed.
 
 Note that the `onedrive` dictionary key can be any string and could facilitate multiple instances running from the same configuration file with different keys.
 
@@ -71,10 +71,10 @@ Depending on your installation you may need to use `pip3` instead.
 pip install graph-onedrive
 ```
 
-If you plan to use YAML formatted config files, then install the yaml optional dependency:
+If you plan to use YAML and/or TOML formatted config files, then the optional install dependencies can be installed:
 
 ```console
-pip install 'graph-onedrive[yaml]'
+pip install 'graph-onedrive[yaml,toml]'
 ```
 
 You can also install the in-development version:
@@ -96,7 +96,8 @@ These dependencies provide critical functions for the package to run and will ty
 
 Optional dependencies provide secondary features that are not part of the core package functionality and will not typically be installed automatically. These can be installed manually or as a package extra as described in [installation](#installation).
 
-* [PyYAML](https://pypi.org/project/PyYAML/) - enables yaml config files
+* [PyYAML](https://pypi.org/project/PyYAML/) - enables .yaml config files
+* [TOML](https://pypi.org/project/TOML/) - enables .toml config files
 
 ## Command-line interface
 
@@ -211,7 +212,7 @@ config_path = "config.json"  # path to config file
 config_key = "onedrive"  # config file dictionary key (default = "onedrive")
 my_instance = OneDrive.from_file(config_path, config_key)
 # do stuff
-my_instance.to_file(config_path, config_key)  # optionally resave the config
+my_instance.to_file(config_path, config_key)  # optionally dump the config
 ```
 
 #### c) Using in-line configuration parameters
@@ -227,7 +228,7 @@ tenant = ""
 redirect_url = "http://localhost:8080"
 my_instance = OneDrive(client_id, client_secret_value, tenant, redirect_url)
 # do stuff
-my_instance.to_file(config_path, config_key)  # optionally resave the config
+my_instance.to_file(config_path, config_key)  # optionally dump the config
 ```
 
 ### Authenticating the instance
@@ -346,9 +347,9 @@ Returns:
 
 Create an instance of the OneDrive class from a configuration file.
 
-Note `from_json` and `from_yaml` are alias of `from_file` and are pending depreciation.
+Note `from_json`, `from_yaml`, and `from_toml` are alias of `from_file` and are pending depreciation.
 
-To use yaml config files the corresponding [optional dependencies](#dependencies) are required.
+To use yaml and toml config files the corresponding [optional dependencies](#dependencies) are required.
 
 ```python
 onedrive_instance = graph_onedrive.OneDrive.from_file(
@@ -366,13 +367,13 @@ Returns:
 
 * onedrive_instance (OneDrive) -- OneDrive object instance
 
-#### to_file, to_json, to_yaml
+#### to_file
 
 Save the configuration to a configuration file.
 
-Note `to_json` and `to_yaml` are alias of `to_file` and are pending depreciation.
+Note `to_json`, `to_yaml`, and `to_toml` are alias of `to_file` and are pending depreciation.
 
-To use yaml config files the corresponding [optional dependencies](#dependencies) are required.
+To use yaml or toml config files the corresponding [optional dependencies](#dependencies) are required.
 
 ```python
 onedrive_instance.to_file(config_path="config.json", config_key="onedrive")
@@ -555,7 +556,7 @@ Keyword arguments:
 
 * link_type (str) -- type of sharing link to create, either "view", "edit", or ("embed" for OneDrive personal only) (default = "view")
 * password (str) -- password for the sharing link (OneDrive personal only) (default = None)
-* expiration (datetime) -- expiration of the sharing link, computer local timezone assummed for 'native' datetime objects (default = None)
+* expiration (datetime) -- expiration of the sharing link, computer local timezone assumed for 'native' datetime objects (default = None)
 * scope (str) -- "anonymous" for anyone with the link, or ("organization" to limit to the tenant for OneDrive Business) Note businesses may choose to disable anonymous links which will result in an error (default = "anonymous")
 
 Returns:

--- a/docs/examples/config.toml
+++ b/docs/examples/config.toml
@@ -1,0 +1,7 @@
+# Note that using toml config files requires the optional dependency TOML.
+[onedrive]
+tenant_id = ""  # required
+client_id = ""  # required
+client_secret_value = ""  # required
+redirect_url = "http://localhost:8080"  # optional, remove line if unused
+refresh_token = ""  # optional, remove line if unused

--- a/docs/examples/config.yaml
+++ b/docs/examples/config.yaml
@@ -1,9 +1,7 @@
 # Note that using yaml config files requires the optional dependency PyYAML.
-# Required: add values below for tenant_id, client_id, and client_secret_value.
-# Optional: redirect_url and refresh_token are optional, these lines can be removed.
 onedrive:
-    tenant_id:
-    client_id:
-    client_secret_value:
-    redirect_url: http://localhost:8080
-    refresh_token: null
+    tenant_id:  # required
+    client_id:  # required
+    client_secret_value:  # required
+    redirect_url: http://localhost:8080  # optional, line can be removed
+    refresh_token: null  # optional, line can be removed

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,6 @@ pyyaml
 respx
 toml
 tox
+types-aiofiles
+types-PyYAML
+types-toml

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,8 @@ console_scripts =
     graph-onedrive = graph_onedrive._cli:main
 
 [options.extras_require]
+toml =
+    toml
 yaml =
     pyyaml
 

--- a/src/graph_onedrive/_config.py
+++ b/src/graph_onedrive/_config.py
@@ -1,0 +1,148 @@
+"""Configuration file related functions.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from typing import Optional
+
+# Set logger
+logger = logging.getLogger(__name__)
+
+# import the PyYAML optional dependency
+try:
+    import yaml
+
+    optionals_yaml = True
+    logger.debug("yaml imported successfully, YAML config files supported")
+except ImportError:
+    optionals_yaml = False
+    logger.debug("yaml could not be imported, YAML config files not supported")
+
+# import the TOML optional dependency
+try:
+    import toml
+
+    optionals_toml = True
+    logger.debug("toml imported successfully, TOML config files supported")
+except ImportError:
+    optionals_toml = False
+    logger.debug("toml could not be imported, TOML config files not supported")
+
+# Create a tuple of acceptable config file extensions, typically used for str.endswith()
+if optionals_yaml and optionals_toml:
+    CONFIG_EXTS: tuple[str, ...] = (".json", ".yaml", ".toml")
+elif optionals_yaml:
+    CONFIG_EXTS = (".json", ".yaml")
+elif optionals_toml:
+    CONFIG_EXTS = (".json", ".toml")
+else:
+    CONFIG_EXTS = (".json",)
+
+
+def load_config(
+    config_path: str | Path, config_key: str | None = None
+) -> dict[str, Any]:
+    """INTERNAL: Loads a config dictionary object from a file.
+    Positional arguments:
+        config_path (str|Path) -- path to configuration file
+        config_key (str) -- key of the item storing the configuration (default = None)
+    Returns:
+        config (dict) -- returns the decoded dictionary contents
+    """
+    # check the file type
+    _check_file_type(config_path)
+
+    # read the config file
+    with open(config_path) as config_file:
+        if str(config_path).endswith(".json"):
+            logger.debug(f"loading {config_path} as a json file")
+            config = json.load(config_file)
+        elif str(config_path).endswith(".yaml"):
+            logger.debug(f"loading {config_path} as a yaml file")
+            config = yaml.safe_load(config_file)
+        elif str(config_path).endswith(".toml"):
+            logger.debug(f"loading {config_path} as a toml file")
+            config = toml.load(config_file)
+        else:
+            raise NotImplementedError("config file type not supported")
+
+    # return raw data if option set
+    if config_key is None:
+        logger.debug(f"returning the raw data without checking the contents")
+        return config
+
+    # return the configuration after checking that the config key
+    try:
+        return config[config_key]
+    except KeyError:
+        raise KeyError(
+            f"config_key '{config_key}' not found in '{Path(config_path).name}'"
+        )
+
+
+def dump_config(
+    config: dict[str, str], config_path: str | Path, config_key: str
+) -> None:
+    """INTERNAL: Dumps a config dictionary object to a file.
+    Positional arguments:
+        config (dict) -- dictionary of key value pairs
+        config_path (str|Path) -- path to configuration file
+        config_key (str) -- key of the item storing the configuration
+    """
+    # Load existing file
+    try:
+        main_config = load_config(config_path)
+        logger.debug(f"{config_path} file already exists, data loaded")
+    except FileNotFoundError:
+        main_config = {}
+        logger.debug(f"{config_path} does not yet exist, new file will be created")
+
+    # Update values
+    main_config.update({config_key: config})
+
+    # Dump to file
+    with open(config_path, "w") as config_file:
+        if str(config_path).endswith(".json"):
+            logger.debug(f"dumping data to {config_path} as a json file")
+            json.dump(main_config, config_file, indent=4)
+        elif str(config_path).endswith(".yaml"):
+            logger.debug(f"dumping data to {config_path} as a yaml file")
+            yaml.safe_dump(main_config, config_file)
+        elif str(config_path).endswith(".toml"):
+            logger.debug(f"dumping data to {config_path} as a toml file")
+            toml.dump(main_config, config_file)
+        else:
+            raise NotImplementedError("config file type not supported")
+
+
+def _check_file_type(
+    file_path: str | Path, accepted_formats: tuple[str, ...] = CONFIG_EXTS
+) -> bool:
+    """INTERNAL: Checks a file extension type compared to a tuple of acceptable types.
+    Positional arguments:
+        file_path (str|Path) -- a path to a file
+    Keyword arguments:
+        accepted_formats (tuple) -- tuple of acceptable file extensions (default = (".json", ".yaml", ".toml"))
+    Returns:
+        (bool) -- True if acceptable, otherwise raises TypeError
+    """
+    # Return true if the file has an acceptable extension
+    if str(file_path).endswith(accepted_formats):
+        return True
+
+    # Raise TypeErrors but provide hints for toml and yaml files
+    if str(file_path).endswith(".yaml"):
+        raise TypeError(
+            f"file path was to yaml file but PyYAML is not installed, Hint: 'pip install pyyaml'"
+        )
+    elif str(file_path).endswith(".toml"):
+        raise TypeError(
+            f"file path was to toml file but TOML is not installed, Hint: 'pip install toml'"
+        )
+    else:
+        raise TypeError(
+            f"file path must have {' or '.join([i for i in accepted_formats])} extension"
+        )

--- a/src/graph_onedrive/_decorators.py
+++ b/src/graph_onedrive/_decorators.py
@@ -6,6 +6,10 @@ from functools import wraps
 from typing import no_type_check
 
 
+# Set logger
+logger = logging.getLogger(__name__)
+
+
 @no_type_check
 def token_required(func):
     """INTERNAL: Graph-OneDrive decorator to check for and refresh the access token when calling methods."""
@@ -19,7 +23,7 @@ def token_required(func):
         now = datetime.timestamp(datetime.now())
         # Refresh access token if expires does not exist or has expired
         if expires <= now:
-            logging.info(
+            logger.info(
                 "access token expired, redeeming refresh token for new access token"
             )
             onedrive_instance._get_token()

--- a/src/graph_onedrive/_manager.py
+++ b/src/graph_onedrive/_manager.py
@@ -10,6 +10,10 @@ from typing import Generator
 from graph_onedrive._onedrive import OneDrive
 
 
+# Set logger
+logger = logging.getLogger(__name__)
+
+
 @contextmanager
 def OneDriveManager(
     config_path: str | Path, config_key: str = "onedrive"
@@ -22,8 +26,8 @@ def OneDriveManager(
     Returns:
         onedrive_instance (OneDrive) -- OneDrive object instance
     """
-    logging.info("OneDriveManager creating instance")
+    logger.info("OneDriveManager creating instance")
     onedrive_instance = OneDrive.from_file(config_path, config_key)
     yield onedrive_instance
-    logging.info("OneDriveManager saving instance configuration to file")
+    logger.info("OneDriveManager saving instance configuration to file")
     onedrive_instance.to_file(config_path, config_key)

--- a/tests/_config_test.py
+++ b/tests/_config_test.py
@@ -1,0 +1,182 @@
+"""Tests the config functions using pytest."""
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from unittest import mock
+
+import pytest
+import toml
+import yaml
+
+from .conftest import ACCESS_TOKEN
+from .conftest import AUTH_CODE
+from .conftest import CLIENT_ID
+from .conftest import CLIENT_SECRET
+from .conftest import REDIRECT
+from .conftest import REFRESH_TOKEN
+from .conftest import SCOPE
+from .conftest import TENANT
+from .conftest import TESTS_DIR
+from graph_onedrive._config import _check_file_type
+from graph_onedrive._config import dump_config
+from graph_onedrive._config import load_config
+
+
+class TestLoad:
+    """Tests the load_config function."""
+
+    @pytest.mark.parametrize(
+        "config_path, config_key",
+        [
+            ("config.json", "onedrive"),
+            ("test.yaml", "test_2"),
+            ("unknown.txt.toml", "one more test"),
+        ],
+    )
+    def test_load_config(self, tmp_path, config_path, config_key):
+        # Make a temporary config file
+        config = {
+            config_key: {
+                "tenant_id": TENANT,
+                "client_id": CLIENT_ID,
+                "client_secret_value": CLIENT_SECRET,
+                "redirect_url": REDIRECT,
+                "refresh_token": REFRESH_TOKEN,
+            }
+        }
+        temp_dir = Path(tmp_path, "temp_config")
+        temp_dir.mkdir()
+        config_path = Path(temp_dir, config_path)
+        with open(config_path, "w") as fw:
+            if str(config_path).endswith(".json"):
+                json.dump(config, fw)
+            elif str(config_path).endswith(".yaml"):
+                yaml.safe_dump(config, fw)
+            elif str(config_path).endswith(".toml"):
+                toml.dump(config, fw)
+        # Test load
+        data = load_config(config_path, config_key)
+        assert data == config[config_key]
+
+    def test_load_config_raw(self, tmp_path):
+        config_key = "onedrive"
+        # Make a temporary config file
+        config = {
+            config_key: {
+                "tenant_id": TENANT,
+                "client_id": CLIENT_ID,
+                "client_secret_value": CLIENT_SECRET,
+                "redirect_url": REDIRECT,
+                "refresh_token": REFRESH_TOKEN,
+            },
+            "other data": 1234,
+        }
+        temp_dir = Path(tmp_path, "temp_config")
+        temp_dir.mkdir()
+        config_path = Path(temp_dir, "raw.yaml")
+        with open(config_path, "w") as fw:
+            if str(config_path).endswith(".json"):
+                json.dump(config, fw)
+            elif str(config_path).endswith(".yaml"):
+                yaml.safe_dump(config, fw)
+            elif str(config_path).endswith(".toml"):
+                toml.dump(config, fw)
+        # Test load
+        data = load_config(config_path)
+        assert data == config
+
+    def test_load_config_failure(self):
+        ...
+
+
+class TestDump:
+    """Tests the dump_config function."""
+
+    @pytest.mark.parametrize(
+        "config_path",
+        ["config.json", "test.yaml", "unknown.txt.toml"],
+    )
+    def test_dump_config(self, tmp_path, config_path):
+        config_key: str = "onedrive"
+        initial_file: Dict[str, Any] = {
+            config_key: {
+                "tenant_id": TENANT,
+                "client_id": CLIENT_ID,
+                "client_secret_value": CLIENT_SECRET,
+                "redirect_url": REDIRECT,
+                "refresh_token": REFRESH_TOKEN,
+            },
+            "other data": 1234,
+        }
+        temp_dir = Path(tmp_path, "temp_config")
+        temp_dir.mkdir()
+        config_path = Path(temp_dir, config_path)
+        with open(config_path, "w") as fw:
+            if str(config_path).endswith(".json"):
+                json.dump(initial_file, fw)
+            elif str(config_path).endswith(".yaml"):
+                yaml.safe_dump(initial_file, fw)
+            elif str(config_path).endswith(".toml"):
+                toml.dump(initial_file, fw)
+        # Test load
+        new_config = {
+            "tenant_id": TENANT,
+            "client_id": CLIENT_ID,
+            "client_secret_value": CLIENT_SECRET,
+            "redirect_url": REDIRECT,
+            "refresh_token": "new",
+        }
+        dump_config(new_config, config_path, config_key)
+        # Verify data
+        with open(config_path) as fr:
+            if str(config_path).endswith(".json"):
+                read_data = json.load(fr)
+            elif str(config_path).endswith(".yaml"):
+                read_data = yaml.safe_load(fr)
+            elif str(config_path).endswith(".toml"):
+                read_data = toml.load(fr)
+        initial_file[config_key]["refresh_token"] = "new"
+        assert read_data == initial_file
+
+    def test_dump_config_failure(self):
+        ...
+
+
+class TestFileTypeCheck:
+    """Tests the _check_file_type function."""
+
+    @pytest.mark.parametrize(
+        "file_path, accepted_formats",
+        [
+            ("config.json", (".json",)),
+            ("test.yaml", (".json", ".yaml")),
+            ("unknown.txt.toml", (".json", ".yaml", ".toml")),
+        ],
+    )
+    def test_check_file_type(self, file_path, accepted_formats):
+        result = _check_file_type(file_path, accepted_formats)
+        assert result == True
+
+    @pytest.mark.parametrize(
+        "file_path, accepted_formats, exp_msg",
+        [
+            ("config.json", (".txt",), "file path must have .txt extension"),
+            (
+                "test.yaml",
+                (".json",),
+                "file path was to yaml file but PyYAML is not installed, Hint: 'pip install pyyaml'",
+            ),
+            (
+                "unknown.txt.toml",
+                (".json", ".yaml"),
+                "file path was to toml file but TOML is not installed, Hint: 'pip install toml'",
+            ),
+        ],
+    )
+    def test_check_file_type_failure(self, file_path, accepted_formats, exp_msg):
+        with pytest.raises(TypeError) as excinfo:
+            _check_file_type(file_path, accepted_formats)
+        (msg,) = excinfo.value.args
+        assert msg == exp_msg


### PR DESCRIPTION
Adds support for [TOML](https://en.wikipedia.org/wiki/TOML) files to be used as the config file directly with the package.

* [NEW] from_file and to_file methods support .toml files
* [NEW] CLI supports toml files
* [NEW] optional install added for toml support, use `pip install 'graph-onedrive[toml]'`
* [IMPROVED] documentation updated, including new example config.toml file
* [IMPROVED] logging improved to use a logger by default
* [IMPROVED] removed code duplication by adding new _config.py file (& associated tests)
* [FIXED] CLI logging should now display logs properly
* [DEPRECIATED] from_toml and to_toml methods added but with pending depreciation warning, use from_file and to_file instead

On older versions you can load the config data in your script into a Python dictionary and then create an OneDrive instance using OneDrive.from_dict(...). This workflow is still suggested for unsupported configuration file formats.