### PR TITLE
added dest_dir argument to download_file method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add destination argument to download_file method (Issue [#30](https://github.com/dariobauer/graph-onedrive/issues/30))
 * Fixed bug in download_file method when verbose was set to false (Issue [#29](https://github.com/dariobauer/graph-onedrive/issues/29))
 
 ## Released

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -676,10 +676,10 @@ Returns:
 Downloads a file to the current working directory asynchronously with multiple concurrent http requests file files larger than 1mb.
 Note folders cannot be downloaded, you need to implement a loop instead.
 
-Future development improvement: specify the file location and name.
-
 ```python
-file_name = my_instance.download_file(item_id, max_connections=8, verbose=False)
+file_path = my_instance.download_file(
+    item_id, max_connections=8, dest_dir=None, verbose=False
+)
 ```
 
 Positional arguments:
@@ -689,11 +689,12 @@ Positional arguments:
 Keyword arguments:
 
 * max_connections (int) -- max concurrent open http requests, refer throttling warning in the gotcha section at the bottom of the docs
+* dest_dir (str | Path) -- destination directory for the downloaded file, default is current working directory (default = None)
 * verbose (bool) -- prints the download progress (default = False)
 
 Returns:
 
-* file_name (str) -- returns the name of the file including extension
+* file_path (Path) -- returns the path to the downloaded file including extension
 
 #### upload_file
 

--- a/src/graph_onedrive/__init__.py
+++ b/src/graph_onedrive/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.1dev1"
+__version__ = "0.3.1dev2"
 
 import logging
 


### PR DESCRIPTION
Allows users to specify a destination directory when downloading files.

Usage: `file_path = onedrive.download_file(file_id, dest_dir=dest_dir)`

Resolves Issue #30 