### PR TITLE
Remove Support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,37 +6,36 @@ name: Tests
 on:
   pull_request:
     branches:
-    - main
+      - main
     paths-ignore:
-    - 'docs/**'
+      - "docs/**"
   push:
     branches:
-    - main
+      - main
 
 jobs:
   test:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10"]
         include:
-         - os: windows-latest
-           python-version: '3.7'
-         - os: macos-latest
-           python-version: '3.9'
+          - os: windows-latest
+            python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.9"
 
     steps:
-    - name: Check out repository code
-      uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip virtualenv setuptools wheel
-        pip install tox
-    - name: Test using tox
-      run: tox -e py
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip virtualenv setuptools wheel
+          pip install tox
+      - name: Test using tox
+        run: tox -e py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,26 +3,26 @@ ci:
   autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
       - id: setup-cfg-fmt
   - repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.9.0
+    rev: v3.10.0
     hooks:
       - id: reorder-python-imports
         name: Reorder Python imports (src, tests)
         args: ["--application-directories", "src"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
+    rev: v3.10.1
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
-    - id: black
+      - id: black
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.13.0
+    rev: 1.15.0
     hooks:
       - id: blacken-docs
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -46,7 +46,7 @@ repos:
       - id: fix-byte-order-marker
       - id: end-of-file-fixer
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.4.1
     hooks:
       - id: mypy
         additional_dependencies: [types-aiofiles, types-PyYAML, types-toml]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Python 3.7 has reached end of life so removed support and upgraded package
 
 ## Released
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Note that some Microsoft work and school accounts will not allow apps to connect
 
 ## Installation
 
-The package currently requires Python 3.7 or greater.
+The package currently requires Python 3.8 or greater.
+The last version to support Python 3.7 was release 0.4.0 which can still be installed.
 
 Install and update using [pip](https://pip.pypa.io/en/stable/getting-started/) which will use the releases hosted on [PyPI][pypi]. Further options in the docs.
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -15,20 +15,20 @@ Note that some Microsoft work and school accounts will not allow apps to connect
 
 To interact with the Graph API, an app needs to be registered through the [Azure portal](https://portal.azure.com/). Detailed documentation on how to do this is [available directly from Microsoft](https://docs.microsoft.com/en-us/graph/auth-register-app-v2?context=graph%2Fapi%2F1.0&view=graph-rest-1.0).
 
-Setup Option | Description
----|---
-Supported account types | This is related to the tenant described in the next section. Essentially the more restrictive, the easier it is to get the app registered.
-Redirect URI | It is recommended this is left as `Web` to `http://localhost`.
+| Setup Option            | Description                                                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Supported account types | This is related to the tenant described in the next section. Essentially the more restrictive, the easier it is to get the app registered. |
+| Redirect URI            | It is recommended this is left as `Web` to `http://localhost`.                                                                             |
 
 #### Step 2: Obtain authentication details
 
 You need to obtain your registered app's authentication details from the [Azure portal](https://portal.azure.com/) to use in the package for authentication.
 
-Parameter | Location within Azure Portal | Description
----|---|---
-Directory (tenant) ID | App registrations > *your app name* > Overview | The tenant is used to restrict an app to certain accounts. `common` allows both personal Microsoft accounts as well as work/school accounts to use the app. `organizations`, and `consumers` each only allow these account types. All of these types are known as multi-tenant and require more security processes be passed to ensure that you are a legitimate developer. On the contrary, single-tenant apps restrict the app to only one work/school account (i.e. typically one company) and therefore have far fewer security requirements. Single tenants are either a GUID or domain. Refer to the [Azure docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints) for details.
-Application (client) ID | App registrations > *your app name* > Overview | The application ID that's assigned to your app. You can find this information in the portal where you registered your app. Note that this is not the client secret id but the id of the app itself.
-Client secret value | App registrations > *your app name* > Certificates & secrets | The client secret that you generated for your app in the app registration portal. Note that this allows you to set an expiry and should be checked if your app stops working. The client secret is hidden after the initial generation so it is important to copy it and keep it secure.
+| Parameter               | Location within Azure Portal                                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Directory (tenant) ID   | App registrations > *your app name* > Overview               | The tenant is used to restrict an app to certain accounts. `common` allows both personal Microsoft accounts as well as work/school accounts to use the app. `organizations`, and `consumers` each only allow these account types. All of these types are known as multi-tenant and require more security processes be passed to ensure that you are a legitimate developer. On the contrary, single-tenant apps restrict the app to only one work/school account (i.e. typically one company) and therefore have far fewer security requirements. Single tenants are either a GUID or domain. Refer to the [Azure docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints) for details. |
+| Application (client) ID | App registrations > *your app name* > Overview               | The application ID that's assigned to your app. You can find this information in the portal where you registered your app. Note that this is not the client secret id but the id of the app itself.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| Client secret value     | App registrations > *your app name* > Certificates & secrets | The client secret that you generated for your app in the app registration portal. Note that this allows you to set an expiry and should be checked if your app stops working. The client secret is hidden after the initial generation so it is important to copy it and keep it secure.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 WARNING: The client secret presents a security risk if exposed. It is recommended to revoke the client secret immediately if it becomes exposed.
 
@@ -60,7 +60,8 @@ The `redirect_url` and `refresh_token` values are default so these lines can be 
 
 #### Requirements
 
-The package currently requires Python 3.7 or greater.
+The package currently requires Python 3.8 or greater.
+The last version to support Python 3.7 was release 0.4.0 which can still be installed.
 
 #### Install
 
@@ -113,11 +114,11 @@ graph-onedrive [-h] [-c] [-a] [-i] [-V] [-f PATH] [-k KEY]
 
 One of the main actions must be given as an input.
 
-Action argument | Description
----|---
--c, --configure | Create a new configuration file, or add to an existing one with a different dictionary key
--a, --authenticate | Authenticate a configuration file
--i, --instance | Interact with OneDrive to test your config and perform simple tasks
+| Action argument    | Description                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| -c, --configure    | Create a new configuration file, or add to an existing one with a different dictionary key |
+| -a, --authenticate | Authenticate a configuration file                                                          |
+| -i, --instance     | Interact with OneDrive to test your config and perform simple tasks                        |
 
 You can combine these to run multiple tasks in succession, with a common one being `graph-onedrive -cai` which will create a config file, authenticate it, and then run an instance.
 
@@ -125,10 +126,10 @@ You can combine these to run multiple tasks in succession, with a common one bei
 
 You can use flags to specify the config file path and/or dictionary key.
 
-Optional argument | Description
----|---
--f, --file PATH | Optional path to config file
--k, --key KEY | Optional config file dictionary key
+| Optional argument | Description                         |
+| ----------------- | ----------------------------------- |
+| -f, --file PATH   | Optional path to config file        |
+| -k, --key KEY     | Optional config file dictionary key |
 
 Use these flags by using the flag followed by the input, for example:
 
@@ -138,10 +139,10 @@ graph-onedrive -cai -f "config.json" -k "onedrive"
 
 ### Other commands
 
-Other arguments | Description
----|---
--V, --version | Returns the version of Graph-Onedrive installed
--h, --help | Displays help, including a list of attributes
+| Other arguments | Description                                     |
+| --------------- | ----------------------------------------------- |
+| -V, --version   | Returns the version of Graph-Onedrive installed |
+| -h, --help      | Displays help, including a list of attributes   |
 
 ## Limitations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ["py37", "py38", "py39"]
+target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.coverage.run]
 plugins = ["covdefaults",]
@@ -41,7 +41,7 @@ disallow_untyped_defs = false
 legacy_tox_ini = """
 [tox]
 envlist =
-    py{37,38,39,310}
+    py{38,39,310}
     style-and-typing
 skip_missing_interpreters = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     aiofiles
     httpx
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = true
 package_dir = = src
 


### PR DESCRIPTION
Python 3.7 has reached "end of life". As such dependencies have dropped support for it which means that Graph OneDrive tests are now failing.

This pull request removes the support requirement for Python 3.7 as well as the tests for it.

This version should still work on 3.7 but in the future this may be broken without notice.

Release 0.4.0 is the last release to formally support Python 3.7.