### PR TITLE
Disable reorder-python-imports dependancy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,13 @@ repos:
     rev: v2.5.0
     hooks:
       - id: setup-cfg-fmt
-  - repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
-    hooks:
-      - id: reorder-python-imports
-        name: Reorder Python imports (src, tests)
-        args: ["--application-directories", "src"]
+  # Disable reorder-python-imports due to incompatability with Black 24 (Issue #57)
+  # - repo: https://github.com/asottile/reorder-python-imports
+  #   rev: v3.12.0
+  #   hooks:
+  #     - id: reorder-python-imports
+  #       name: Reorder Python imports (src, tests)
+  #       args: ["--application-directories", "src"]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0
     hooks:


### PR DESCRIPTION
Disable the reorder-python-imports dependancy due to incompatibility with Black 24 (Issue #57).