### PR TITLE
Depreciate Python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           - os: windows-latest
             python-version: "3.9"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
   #       name: Reorder Python imports (src, tests)
   #       args: ["--application-directories", "src"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.16.0
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/blacken-docs
@@ -47,7 +47,7 @@ repos:
       - id: fix-byte-order-marker
       - id: end-of-file-fixer
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
+    rev: v1.11.1
     hooks:
       - id: mypy
         additional_dependencies: [types-aiofiles, types-PyYAML, types-toml]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Python 3.7 has reached end of life so removed support and upgraded package
+* Python 3.7 and 3.8 have reached end of life so support was removed and the code upgraded
 
 ## Released
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Note that some Microsoft work and school accounts will not allow apps to connect
 
 ## Installation
 
-The package currently requires Python 3.8 or greater.
-The last version to support Python 3.7 was release 0.4.0 which can still be installed.
+The package currently requires Python 3.9 or greater.
+The last version to support Python 3.7 and 3.8 was release 0.4.0 which can still be installed.
 
 Install and update using [pip](https://pip.pypa.io/en/stable/getting-started/) which will use the releases hosted on [PyPI][pypi]. Further options in the docs.
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -60,8 +60,8 @@ The `redirect_url` and `refresh_token` values are default so these lines can be 
 
 #### Requirements
 
-The package currently requires Python 3.8 or greater.
-The last version to support Python 3.7 was release 0.4.0 which can still be installed.
+The package currently requires Python 3.9 or greater.
+The last version to support Python 3.7 and 3.8 was release 0.4.0 which can still be installed.
 
 #### Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py39", "py310", "py311", "py312"]
 
 [tool.coverage.run]
 plugins = ["covdefaults",]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     aiofiles
     httpx
-python_requires = >=3.8
+python_requires = >=3.9
 include_package_data = true
 package_dir = = src
 

--- a/src/graph_onedrive/_cli.py
+++ b/src/graph_onedrive/_cli.py
@@ -9,7 +9,7 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Sequence
+from collections.abc import Sequence
 
 from graph_onedrive.__init__ import __version__
 from graph_onedrive._config import CONFIG_EXTS

--- a/src/graph_onedrive/_manager.py
+++ b/src/graph_onedrive/_manager.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator
+from collections.abc import Generator
 
 from graph_onedrive._onedrive import OneDrive
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @contextmanager
 def OneDriveManager(
     config_path: str | Path, config_key: str = "onedrive"
-) -> Generator[OneDrive, None, None]:
+) -> Generator[OneDrive]:
     """Context manager for the OneDrive class, only use this if you want to save and read from a file.
     Positional arguments:
         config_path (str|Path) -- path to configuration file

--- a/tests/_config_test.py
+++ b/tests/_config_test.py
@@ -100,7 +100,7 @@ class TestDump:
     )
     def test_dump_config(self, tmp_path, config_path):
         config_key: str = "onedrive"
-        initial_file: Dict[str, Any] = {
+        initial_file: dict[str, Any] = {
             config_key: {
                 "tenant_id": TENANT,
                 "client_id": CLIENT_ID,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -488,7 +488,7 @@ def mock_auth_api():
 
 def side_effect_access_token(request):
     # Parse and decode the request content, typed to help mypy
-    body_encoded: List[Tuple[bytes, bytes]] = urllib.parse.parse_qsl(request.content)
+    body_encoded: list[tuple[bytes, bytes]] = urllib.parse.parse_qsl(request.content)
     body = {key.decode(): value.decode() for (key, value) in body_encoded}
     # Check the content is as expected
     grant_type = body["grant_type"]


### PR DESCRIPTION
Python 3.8 has reached its end of life.

As some dependencies have dropped support for Python 3.8, this change also removes support for Python 3.8 in the development version.
- Min supported version changed to python 3.8
- Documentation updated
- Testing and development environment files updated
- Testing (via Github actions) now includes environments running Python 3.11 and 3.12