### PR TITLE
Improvemments to use installed toml parsers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,6 @@ ci:
   autofix_commit_msg: "[pre-commit.ci] auto fixes from hooks"
   autoupdate_schedule: monthly
 repos:
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.8.0
-    hooks:
-      - id: setup-cfg-fmt
-  # Disable reorder-python-imports due to incompatability with Black 24 (Issue #57)
-  # - repo: https://github.com/asottile/reorder-python-imports
-  #   rev: v3.12.0
-  #   hooks:
-  #     - id: reorder-python-imports
-  #       name: Reorder Python imports (src, tests)
-  #       args: ["--application-directories", "src"]
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.20.0
     hooks:
@@ -42,7 +31,6 @@ repos:
       - id: name-tests-test
       - id: pretty-format-json
         args: ["--autofix", "--no-sort-keys"]
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
       - id: fix-byte-order-marker
       - id: end-of-file-fixer

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include CHANGES.md
 include LICENSE
 include src/graph_onedrive/py.typed
 global-exclude *.pyc
+global-exclude __pycache__

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -61,7 +61,8 @@ The `redirect_url` and `refresh_token` values are default so these lines can be 
 #### Requirements
 
 The package currently requires Python 3.9 or greater.
-The last version to support Python 3.7 and 3.8 was release 0.4.0 which can still be installed.
+
+Release 0.4.0 can be used with Python 3.7 and 3.8.
 
 #### Install
 
@@ -72,16 +73,10 @@ Depending on your installation you may need to use `pip3` instead.
 pip install -U graph-onedrive
 ```
 
-If you plan to use YAML and/or TOML formatted config files, then the optional install dependencies can be installed (yaml, toml, or both):
-
-```console
-pip install -U 'graph-onedrive[yaml,toml]'
-```
-
 You can also install the in-development version:
 
 ```console
-pip install https://github.com/dariobauer/graph-onedrive/archive/main.zip
+pip install -U https://github.com/dariobauer/graph-onedrive/archive/main.zip
 ```
 
 #### Dependencies
@@ -95,10 +90,10 @@ These dependencies provide critical functions for the package to run and will ty
 
 ##### Optional Dependencies
 
-Optional dependencies provide secondary features that are not part of the core package functionality and will not typically be installed automatically. These can be installed manually or as a package extra as described in [installation](#installation).
+Optional dependencies provide secondary features that are not part of the core package functionality. These can be installed manually (e.g. `pip install pyyaml`).
 
 * [PyYAML](https://pypi.org/project/PyYAML/) - enables .yaml config files
-* [TOML](https://pypi.org/project/TOML/) - enables .toml config files
+* [TOML](https://pypi.org/project/TOML/) or [TOML Kit](https://pypi.org/project/tomlkit/) - fully enables .toml config files (tomli, tomli-w, and tomllib can also be used but multiple need to be installed for both read and write file support)
 
 ## Command-line interface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,6 @@ Changes = "https://github.com/dariobauer/graph-onedrive/blob/main/CHANGES.md"
 "Source Code" = "https://github.com/dariobauer/graph-onedrive"
 
 [project.optional-dependencies]
-toml = ["toml"]
-yaml = ["pyyaml"]
-
 # Testing dependencies used by Tox
 # Note: contributors need to install tox before testing, refer CONTRIBUTING.md
 test = [

--- a/tests/_config_test.py
+++ b/tests/_config_test.py
@@ -20,7 +20,6 @@ from .conftest import REFRESH_TOKEN
 from .conftest import SCOPE
 from .conftest import TENANT
 from .conftest import TESTS_DIR
-from graph_onedrive._config import _check_file_type
 from graph_onedrive._config import dump_config
 from graph_onedrive._config import load_config
 
@@ -141,41 +140,3 @@ class TestDump:
         assert read_data == initial_file
 
     def test_dump_config_failure(self): ...
-
-
-class TestFileTypeCheck:
-    """Tests the _check_file_type function."""
-
-    @pytest.mark.parametrize(
-        "file_path, accepted_formats",
-        [
-            ("config.json", (".json",)),
-            ("test.yaml", (".json", ".yaml")),
-            ("unknown.txt.toml", (".json", ".yaml", ".toml")),
-        ],
-    )
-    def test_check_file_type(self, file_path, accepted_formats):
-        result = _check_file_type(file_path, accepted_formats)
-        assert result == True
-
-    @pytest.mark.parametrize(
-        "file_path, accepted_formats, exp_msg",
-        [
-            ("config.json", (".txt",), "file path must have .txt extension"),
-            (
-                "test.yaml",
-                (".json",),
-                "file path was to yaml file but PyYAML is not installed, Hint: 'pip install pyyaml'",
-            ),
-            (
-                "unknown.txt.toml",
-                (".json", ".yaml"),
-                "file path was to toml file but TOML is not installed, Hint: 'pip install toml'",
-            ),
-        ],
-    )
-    def test_check_file_type_failure(self, file_path, accepted_formats, exp_msg):
-        with pytest.raises(TypeError) as excinfo:
-            _check_file_type(file_path, accepted_formats)
-        (msg,) = excinfo.value.args
-        assert msg == exp_msg


### PR DESCRIPTION
- Removed toml and pyyaml install options, this can be done manually (docs updated accordingly)
- Added parser support for tomllib, tomli, tomli-w, tomlkit
- Cleaned up pre-commit config to remove redundant checks
- Updated MANIFEST.in to exclude __pycache__